### PR TITLE
Support flatpath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ gulp.task('create-json-blob', function() {
 });
 ```
 
-Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation, `flat` as true removes the path and therefore the resulting json object is one layer deep. Be careful to avoid duplicate filenames when using the flat option.
+Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation. `flat` as true removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option). `flatpath` will like `flat` result in a one layer deep json object, but where the path is included, separated with double underscores.
 
 ```javascript
       .pipe(fc2json('contents.json', {
         extname : false, // default is true
-        flat : true // default is false
+        flat : true, // default is false
+        flatpath: true // default is false
       }))
 ```
 

--- a/index.js
+++ b/index.js
@@ -58,6 +58,12 @@ module.exports = function (dest, options) {
         id = id.split(':').reverse()[0]; 
       }; 
 
+      if (options.flatpath === true) {
+        // 'foo:bar:baz.txt' => 'foo__bar__baz.txt'
+        // 'foo:bar:baz' => 'foo__bar__baz'
+        id = id.replace(/:/g,'__');
+      }
+
       var contents = file.contents.toString("utf-8");
       nconf.set(guid + ':' + id, contents);
 


### PR DESCRIPTION
`flatpath` will like `flat` result in a one layer deep json object, but where the path is included, separated with double underscores